### PR TITLE
Relax constraint on sinatra

### DIFF
--- a/sinatra_swagger_ui.gemspec
+++ b/sinatra_swagger_ui.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency "sinatra", "2.0.0"
+  spec.add_runtime_dependency "sinatra", "~> 2.0"
 end


### PR DESCRIPTION
Forcing a specific version of sinitra prevent to access other versions of sinatra